### PR TITLE
Add WskError support to the activation command

### DIFF
--- a/tools/go-cli/go-whisk-cli/commands/activation.go
+++ b/tools/go-cli/go-whisk-cli/commands/activation.go
@@ -17,262 +17,288 @@ limitations under the License.
 package commands
 
 import (
-        "errors"
-        "fmt"
-        "os"
-        "os/signal"
-        "syscall"
-        "time"
+    "errors"
+    "fmt"
+    "os"
+    "os/signal"
+    "syscall"
+    "time"
 
-        "../../go-whisk/whisk"
+    "../../go-whisk/whisk"
 
-        "github.com/fatih/color"
-        "github.com/spf13/cobra"
+    //"github.com/fatih/color"
+    "github.com/spf13/cobra"
 )
 
 const (
-        PollInterval = time.Second * 2
-        Delay        = time.Second * 5
+    PollInterval = time.Second * 2
+    Delay        = time.Second * 5
 )
 
 // activationCmd represents the activation command
 var activationCmd = &cobra.Command{
-        Use:   "activation",
-        Short: "work with activations",
+    Use:   "activation",
+    Short: "work with activations",
 }
 
 var activationListCmd = &cobra.Command{
-        Use:   "list <namespace string>",
-        Short: "list activations",
-
-        Run: func(cmd *cobra.Command, args []string) {
-                var err error
-                qName := qualifiedName{}
-                if len(args) == 1 {
-                        qName, err = parseQualifiedName(args[0])
-                        if err != nil {
-                                fmt.Printf("error: %s", err)
-                                return
-                        }
-                        ns := qName.namespace
-                        if len(ns) == 0 {
-                                err = errors.New("No valid namespace detected.  Make sure that namespace argument is preceded by a \"/\"")
-                                fmt.Printf("error: %s\n", err)
-                                return
-                        }
-
-                        client.Namespace = ns
-
-                        if pkg := qName.packageName; len(pkg) > 0 {
-                                // todo :: scope call to package
-                        }
+    Use:   "list <namespace string>",
+    Short: "list activations",
+    SilenceUsage:   true,
+    SilenceErrors:  true,
+    RunE: func(cmd *cobra.Command, args []string) error {
+        var err error
+        qName := qualifiedName{}
+        if len(args) == 1 {
+            if IsDebug() {
+                fmt.Printf("activationListCmd: namespace argument '%#v' is provided\n", args[0])
+            }
+            qName, err = parseQualifiedName(args[0])
+            if err != nil {
+                if IsDebug() {
+                    fmt.Printf("activationListCmd: parseQualifiedName(%#v) error: %s\n", args[0], err)
                 }
+                errStr := fmt.Sprintf("Unable to obtain a valid qualified name: %s", err)
+                werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+                return werr
+            }
+            ns := qName.namespace
+            if len(ns) == 0 {
+                if IsDebug() {
+                    fmt.Printf("activationListCmd: Namespace '%s' is invalid\n", ns)
+                }
+                errStr := fmt.Sprintf("Namespace '%s' is invalid", ns)
+                werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+                return werr
+            }
 
-                options := &whisk.ActivationListOptions{
-                        Name:  flags.activation.action,
-                        Limit: flags.common.limit,
-                        Skip:  flags.common.skip,
-                        Upto:  flags.activation.upto,
-                        Since: flags.activation.since,
-                        Docs:  flags.common.full,
-                }
-                activations, _, err := client.Activations.List(options)
-                if err != nil {
-                        fmt.Println(err)
-                        return
-                }
-                printList(activations)
-        },
+            client.Namespace = ns
+
+            if pkg := qName.packageName; len(pkg) > 0 {
+                // todo :: scope call to package
+            }
+        }
+
+        options := &whisk.ActivationListOptions{
+            Name:  flags.activation.action,
+            Limit: flags.common.limit,
+            Skip:  flags.common.skip,
+            Upto:  flags.activation.upto,
+            Since: flags.activation.since,
+            Docs:  flags.common.full,
+        }
+        activations, _, err := client.Activations.List(options)
+        if err != nil {
+            if IsDebug() {
+                fmt.Printf("activationListCmd: client.Activations.List() error: %s\n", err)
+            }
+            errStr := fmt.Sprintf("Unable to obtain list of activations: %s", err)
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+            return werr
+        }
+
+        // When the --full (URL contains "?docs=true") option is specified, display the entire activation details
+        if options.Docs == true {
+            printFullActivationList(activations)
+        } else {
+            printList(activations)
+        }
+
+        return nil
+    },
 }
 
 var activationGetCmd = &cobra.Command{
-        Use:   "get <id string>",
-        Short: "get activation",
+    Use:   "get <id string>",
+    Short: "get activation",
 
-        Run: func(cmd *cobra.Command, args []string) {
-                if len(args) != 1 {
-                        err := errors.New("Invalid ID argument")
-                        fmt.Println(err)
-                        return
-                }
-                id := args[0]
-                activation, _, err := client.Activations.Get(id)
-                if err != nil {
-                        fmt.Println(err)
-                        return
-                }
+    Run: func(cmd *cobra.Command, args []string) {
+        if len(args) != 1 {
+            err := errors.New("Invalid ID argument")
+            fmt.Println(err)
+            return
+        }
+        id := args[0]
+        activation, _, err := client.Activations.Get(id)
+        if err != nil {
+            fmt.Println(err)
+            return
+        }
 
-                if flags.common.summary {
-                        fmt.Printf("activation result for /%s/%s (%s at %s)", activation.Namespace, activation.Name, activation.Response.Status, time.Unix(activation.End/1000, 0))
-                        printJSON(activation.Response.Result)
-                } else {
-                        fmt.Printf("%s got activation %s\n", color.GreenString("ok:"), boldString(id))
-                        printJSON(activation)
-                }
+        if flags.common.summary {
+            fmt.Printf("activation result for /%s/%s (%s at %s)\n", activation.Namespace, activation.Name, activation.Response.Status, time.Unix(activation.End/1000, 0))
+            printJsonNoColor(activation.Response.Result)
+        } else {
+            //fmt.Printf("%s got activation %s\n", color.GreenString("ok:"), boldString(id))  - Does not work on Windows
+            fmt.Printf("ok: got activation %s\n", id)
+            printJsonNoColor(activation)
+        }
 
-        },
+    },
 }
 
 var activationLogsCmd = &cobra.Command{
-        Use:   "logs",
-        Short: "get the logs of an activation",
+    Use:   "logs",
+    Short: "get the logs of an activation",
 
-        Run: func(cmd *cobra.Command, args []string) {
-                if len(args) != 1 {
-                        err := errors.New("Invalid ID argument")
-                        fmt.Println(err)
-                        return
-                }
+    Run: func(cmd *cobra.Command, args []string) {
+        if len(args) != 1 {
+            err := errors.New("Invalid ID argument")
+            fmt.Println(err)
+            return
+        }
 
-                id := args[0]
-                activation, _, err := client.Activations.Logs(id)
-                if err != nil {
-                        fmt.Println(err)
-                        return
-                }
+        id := args[0]
+        activation, _, err := client.Activations.Logs(id)
+        if err != nil {
+            fmt.Println(err)
+            return
+        }
 
-                fmt.Printf("%s got activation %s logs\n", color.GreenString("ok:"), boldString(id))
+        //fmt.Printf("%s got activation %s logs\n", color.GreenString("ok:"), boldString(id)) - Does not work on Windows
+        fmt.Printf("ok: got activation %s logs\n", id)
 
-                printJSON(activation.Logs)
-        },
+        printJsonNoColor(activation.Logs)
+    },
 }
 
 var activationResultCmd = &cobra.Command{
-        Use:   "result",
-        Short: "get the result of an activation",
+    Use:   "result",
+    Short: "get the result of an activation",
 
-        Run: func(cmd *cobra.Command, args []string) {
-                if len(args) != 1 {
-                        err := errors.New("Invalid ID argument")
-                        fmt.Println(err)
-                        return
-                }
+    Run: func(cmd *cobra.Command, args []string) {
+        if len(args) != 1 {
+            err := errors.New("Invalid ID argument")
+            fmt.Println(err)
+            return
+        }
 
-                id := args[0]
-                result, _, err := client.Activations.Result(id)
-                if err != nil {
-                        fmt.Println(err)
-                        return
-                }
+        id := args[0]
+        result, _, err := client.Activations.Result(id)
+        if err != nil {
+            fmt.Println(err)
+            return
+        }
 
-                fmt.Printf("%s got activation %s result\n", color.GreenString("ok:"), boldString(id))
-                printJSON(result)
-        },
+        //fmt.Printf("%s got activation %s result\n", color.GreenString("ok:"), boldString(id))  - Does not work on Windows
+        fmt.Printf("ok: got activation %s result\n", id)
+        printJsonNoColor(result.Result)
+    },
 }
 
 var activationPollCmd = &cobra.Command{
-        Use:   "poll <namespace string>",
-        Short: "poll continuously for log messages from currently running actions",
+    Use:   "poll <namespace string>",
+    Short: "poll continuously for log messages from currently running actions",
 
-        Run: func(cmd *cobra.Command, args []string) {
-                var name string
-                if len(args) == 1 {
-                        name = args[0]
+    Run: func(cmd *cobra.Command, args []string) {
+        var name string
+        if len(args) == 1 {
+            name = args[0]
+        }
+
+        c := make(chan os.Signal, 1)
+        signal.Notify(c, os.Interrupt)
+        signal.Notify(c, syscall.SIGTERM)
+        go func() {
+            <-c
+            fmt.Println("Poll terminated")
+            os.Exit(1)
+        }()
+        fmt.Println("Enter Ctrl-c to exit.")
+
+        pollSince := time.Now()
+        reported := []string{}
+
+        if flags.activation.sinceSeconds+
+        flags.activation.sinceMinutes+
+        flags.activation.sinceHours+
+        flags.activation.sinceDays ==
+        0 {
+            options := &whisk.ActivationListOptions{
+                Limit: 1,
+                Docs:  true,
+            }
+            activationList, _, _ := client.Activations.List(options)
+            if len(activationList) > 0 {
+                lastActivation := activationList[0]
+                pollSince = time.Unix(lastActivation.Start+1, 0).Add(Delay)
+            }
+        } else {
+            t0 := time.Now()
+
+            duration, err := time.ParseDuration(fmt.Sprintf("%ds %dm %dh",
+                flags.activation.sinceSeconds,
+                flags.activation.sinceMinutes,
+                flags.activation.sinceHours+
+                flags.activation.sinceDays*24,
+            ))
+            if err == nil {
+                pollSince = t0.Add(-duration)
+            }
+        }
+
+        fmt.Println("Polling for logs")
+        localStartTime := time.Now()
+        for {
+            if flags.activation.exit > 0 {
+                localDuration := time.Since(localStartTime)
+                if int(localDuration.Seconds()) > flags.activation.exit {
+                    return
                 }
+            }
 
-                c := make(chan os.Signal, 1)
-                signal.Notify(c, os.Interrupt)
-                signal.Notify(c, syscall.SIGTERM)
-                go func() {
-                        <-c
-                        fmt.Println("Poll terminated")
-                        os.Exit(1)
-                }()
-                fmt.Println("Enter Ctrl-c to exit.")
+            options := &whisk.ActivationListOptions{
+                Name:  name,
+                Since: pollSince.Unix(),
+                Docs:  true,
+            }
 
-                pollSince := time.Now()
-                reported := []string{}
+            activations, _, err := client.Activations.List(options)
+            if err != nil {
+                continue
+            }
 
-                if flags.activation.sinceSeconds+
-                        flags.activation.sinceMinutes+
-                        flags.activation.sinceHours+
-                        flags.activation.sinceDays ==
-                        0 {
-                        options := &whisk.ActivationListOptions{
-                                Limit: 1,
-                                Docs:  true,
-                        }
-                        activationList, _, _ := client.Activations.List(options)
-                        if len(activationList) > 0 {
-                                lastActivation := activationList[0]
-                                pollSince = time.Unix(lastActivation.Start+1, 0).Add(Delay)
-                        }
-                } else {
-                        t0 := time.Now()
-
-                        duration, err := time.ParseDuration(fmt.Sprintf("%ds %dm %dh",
-                                flags.activation.sinceSeconds,
-                                flags.activation.sinceMinutes,
-                                flags.activation.sinceHours+
-                                        flags.activation.sinceDays*24,
-                        ))
-                        if err == nil {
-                                pollSince = t0.Add(-duration)
-                        }
+            for _, activation := range activations {
+                for _, id := range reported {
+                    if id == activation.ActivationID {
+                        continue
+                    }
                 }
+                fmt.Printf("\nActivation: %s (%s)\n", activation.Name, activation.ActivationID)
+                printJSON(activation.Logs)
 
-                fmt.Println("Polling for logs")
-                localStartTime := time.Now()
-                for {
-                        if flags.activation.exit > 0 {
-                                localDuration := time.Since(localStartTime)
-                                if int(localDuration.Seconds()) > flags.activation.exit {
-                                        return
-                                }
-                        }
-
-                        options := &whisk.ActivationListOptions{
-                                Name:  name,
-                                Since: pollSince.Unix(),
-                                Docs:  true,
-                        }
-
-                        activations, _, err := client.Activations.List(options)
-                        if err != nil {
-                                continue
-                        }
-
-                        for _, activation := range activations {
-                                for _, id := range reported {
-                                        if id == activation.ActivationID {
-                                                continue
-                                        }
-                                }
-                                fmt.Printf("\nActivation: %s (%s)\n", activation.Name, activation.ActivationID)
-                                printJSON(activation.Logs)
-
-                                reported = append(reported, activation.ActivationID)
-                                if activationTime := time.Unix(activation.Start, 0); activationTime.After(pollSince) {
-                                        pollSince = activationTime
-                                }
-                        }
-                        time.Sleep(time.Second * 2)
+                reported = append(reported, activation.ActivationID)
+                if activationTime := time.Unix(activation.Start, 0); activationTime.After(pollSince) {
+                    pollSince = activationTime
                 }
-        },
+            }
+            time.Sleep(time.Second * 2)
+        }
+    },
 }
 
 func init() {
 
-        activationListCmd.Flags().StringVarP(&flags.activation.action, "action", "a", "", "retrieve activations for action")
-        activationListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, "skip this many entitites from the head of the collection")
-        activationListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, "only return this many entities from the collection")
-        activationListCmd.Flags().BoolVarP(&flags.common.full, "full", "f", false, "include full entity description")
-        activationListCmd.Flags().Int64Var(&flags.activation.upto, "upto", 0, "return activations with timestamps earlier than UPTO; measured in miliseconds since Th, 01, Jan 1970")
-        activationListCmd.Flags().Int64Var(&flags.activation.since, "since", 0, "return activations with timestamps earlier than UPTO; measured in miliseconds since Th, 01, Jan 1970")
+    activationListCmd.Flags().StringVarP(&flags.activation.action, "action", "a", "", "retrieve activations for action")
+    activationListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, "skip this many entitites from the head of the collection")
+    activationListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, "only return this many entities from the collection")
+    activationListCmd.Flags().BoolVarP(&flags.common.full, "full", "f", false, "include full entity description")
+    activationListCmd.Flags().Int64Var(&flags.activation.upto, "upto", 0, "return activations with timestamps earlier than UPTO; measured in miliseconds since Th, 01, Jan 1970")
+    activationListCmd.Flags().Int64Var(&flags.activation.since, "since", 0, "return activations with timestamps earlier than UPTO; measured in miliseconds since Th, 01, Jan 1970")
 
-        activationGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, "summarize entity details")
+    activationGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, "summarize entity details")
 
-        activationPollCmd.Flags().IntVarP(&flags.activation.exit, "exit", "e", 0, "exit after this many seconds")
-        activationPollCmd.Flags().IntVar(&flags.activation.sinceSeconds, "since-seconds", 0, "start polling for activations this many seconds ago")
-        activationPollCmd.Flags().IntVar(&flags.activation.sinceMinutes, "since-minutes", 0, "start polling for activations this many minutes ago")
-        activationPollCmd.Flags().IntVar(&flags.activation.sinceHours, "since-hours", 0, "start polling for activations this many hours ago")
-        activationPollCmd.Flags().IntVar(&flags.activation.sinceDays, "since-days", 0, "start polling for activations this many days ago")
+    activationPollCmd.Flags().IntVarP(&flags.activation.exit, "exit", "e", 0, "exit after this many seconds")
+    activationPollCmd.Flags().IntVar(&flags.activation.sinceSeconds, "since-seconds", 0, "start polling for activations this many seconds ago")
+    activationPollCmd.Flags().IntVar(&flags.activation.sinceMinutes, "since-minutes", 0, "start polling for activations this many minutes ago")
+    activationPollCmd.Flags().IntVar(&flags.activation.sinceHours, "since-hours", 0, "start polling for activations this many hours ago")
+    activationPollCmd.Flags().IntVar(&flags.activation.sinceDays, "since-days", 0, "start polling for activations this many days ago")
 
-        activationCmd.AddCommand(
-                activationListCmd,
-                activationGetCmd,
-                activationLogsCmd,
-                activationResultCmd,
-                activationPollCmd,
-        )
+    activationCmd.AddCommand(
+        activationListCmd,
+        activationGetCmd,
+        activationLogsCmd,
+        activationResultCmd,
+        activationPollCmd,
+    )
 }

--- a/tools/go-cli/go-whisk-cli/commands/namespace.go
+++ b/tools/go-cli/go-whisk-cli/commands/namespace.go
@@ -46,7 +46,7 @@ var namespaceListCmd = &cobra.Command{
                 fmt.Printf("namespaceListCmd: client.Namespaces.List() error: %s\n", err)
             }
             errStr := fmt.Sprintf("Unable to obtain list of available namspaces: %s", err)
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE) //FIXME MWD exitCode
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
         printList(namespaces)
@@ -71,7 +71,7 @@ var namespaceGetCmd = &cobra.Command{
                 fmt.Printf("namespaceGetCmd: client.Namespaces.Get(%s) error: %s\n", nsName, err)
             }
             errStr := fmt.Sprintf("Unable to obtain namespace entities for namespace '%s': %s", nsName, err)
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE) //FIXME MWD exitCode
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
 

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -66,7 +66,7 @@ var propertySetCmd = &cobra.Command{
         // get current props
         props, err := readProps(Properties.PropsFile)
         if err != nil {
-            errStr := fmt.Sprintf("Unable to set the property value: %s", err)
+            errStr := fmt.Sprintf("Unable to set the property value: %s\n", err)
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -246,13 +246,7 @@ var propertyGetCmd = &cobra.Command{
             }
             if err != nil {
                 errStr := fmt.Sprintf("Unable to obtain API build information: %s", err)
-                var exitCode int
-                if e, ok := err.(*whisk.WskError); ok {
-                    exitCode = e.ExitCode
-                } else {
-                    exitCode = whisk.EXITCODE_ERR_GENERAL
-                }
-                werr := whisk.MakeWskError(errors.New(errStr), exitCode, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+                werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
         }
@@ -315,7 +309,7 @@ func getPropertiesFilePath() (propsFilePath string, werr error) {
             errStr := fmt.Sprintf("Unable to locate properties file '%s'; error %s", Properties.PropsFile, err)
             werr = whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             if IsDebug() {
-                fmt.Printf("getPropertiesFilePath: Home directory '%s' expansion failure: %s", Properties.PropsFile, err)
+                fmt.Printf("getPropertiesFilePath: Home directory '%s' expansion failure: %s\n", Properties.PropsFile, err)
             }
             return propsFilePath, werr
         }
@@ -433,7 +427,7 @@ func readProps(path string) (map[string]string, error) {
     if err != nil {
         // If file does not exist, just return props
         if IsDebug() {
-            fmt.Printf("Unable to read whisk properties file '%s' (file open error: %s); falling back to default properties" ,path, err)
+            fmt.Printf("Unable to read whisk properties file '%s' (file open error: %s); falling back to default properties\n" ,path, err)
         }
         return props, nil
     }

--- a/tools/go-cli/go-whisk-cli/commands/util.go
+++ b/tools/go-cli/go-whisk-cli/commands/util.go
@@ -17,209 +17,255 @@ limitations under the License.
 package commands
 
 import (
-        "errors"
-        "fmt"
-        "strings"
+    "errors"
+    "fmt"
+    "strings"
 
-        "../../go-whisk/whisk"
+    "../../go-whisk/whisk"
 
-        "github.com/fatih/color"
-        prettyjson "github.com/hokaccha/go-prettyjson"
+    "github.com/fatih/color"
+    prettyjson "github.com/hokaccha/go-prettyjson"
 )
 
 type qualifiedName struct {
-        namespace   string
-        packageName string
-        entityName  string
+    namespace   string
+    packageName string
+    entityName  string
 }
 
 func (qName qualifiedName) String() string {
-        output := []string{}
+    output := []string{}
 
-        if len(qName.namespace) > 0 {
-                output = append(output, "/", qName.namespace, "/")
-        }
-        if len(qName.packageName) > 0 {
-                output = append(output, qName.packageName, "/")
-        }
-        output = append(output, qName.entityName)
+    if len(qName.namespace) > 0 {
+        output = append(output, "/", qName.namespace, "/")
+    }
+    if len(qName.packageName) > 0 {
+        output = append(output, qName.packageName, "/")
+    }
+    output = append(output, qName.entityName)
 
-        return strings.Join(output, "")
+    return strings.Join(output, "")
 }
 
+//
+// Parse a (possibly fully qualified) resource name into
+// namespace and name components. If the given qualified
+// name isNone, then this is a default qualified name
+// and it is resolved from properties. If the namespace
+// is missing from the qualified name, the namespace is also
+// resolved from the property file.
+//
+// Return a qualifiedName struct
+//
+// Examples:
+//      foo => qName {namespace: "_", entityName: foo}
+//      pkg/foo => qName {namespace: "_", entityName: pkg/foo}
+//      /ns/foo => qName {namespace: ns, entityName: foo}
+//      /ns/pkg/foo => qName {namespace: ns, entityName: pkg/foo}
+//
 func parseQualifiedName(name string) (qName qualifiedName, err error) {
 
-        if len(name) > 0 && name[0] == '/' {
-                parts := strings.Split(name, "/")
-                qName.namespace = parts[1]
+    // If name has a preceding delimiter (/), it contains a namespace
+    if len(name) > 0 && name[0] == '/' {
+        parts := strings.Split(name, "/")
+        qName.namespace = parts[1]
 
-                if len(parts) > 2 {
-                       qName.entityName = strings.Join(parts[2:], "")
-                } else {
-                        qName.entityName = name
-                }
-        } else if len(name) > 0 {
-                qName.entityName = name
-
-                if Properties.Namespace != "" {
-                        qName.namespace = Properties.Namespace
-                } else {
-                        qName.namespace = "_"
-                }
+        if len(parts) > 2 {
+            qName.entityName = strings.Join(parts[2:], "")
         } else {
-                err = whisk.MakeWskError(errors.New("Invalid name format"), whisk.EXITCODE_ERR_GENERAL,
-                        whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE )
+            qName.entityName = name
         }
+    // otherwise the name does not specify a namespace, so default the namespace
+    // to the namespace value set in the properties file; if that is not set, use "_"
+    } else if len(name) > 0 {
+        qName.entityName = name
 
+        if Properties.Namespace != "" {
+            qName.namespace = Properties.Namespace
+        } else {
+            qName.namespace = "_"
+        }
+    } else {
         if IsDebug() {
-                fmt.Printf("Package entityName: %s\n", qName.entityName)
-                fmt.Printf("Package namespace: %s\n", qName.namespace)
+            fmt.Println("parseQualifiedName: Error - empty name string could not be parsed")
         }
+        err = whisk.MakeWskError(errors.New("Invalid name format"), whisk.EXITCODE_ERR_GENERAL,
+            whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE )
+    }
 
-        return qName, err
+    if IsDebug() {
+        fmt.Printf("Package entityName: %s\n", qName.entityName)
+        fmt.Printf("Package namespace: %s\n", qName.namespace)
+    }
+
+    return qName, err
 }
 
 func parseGenericArray(args []string) (whisk.Annotations, error) {
-        parsed := make(whisk.Annotations, 0)
+    parsed := make(whisk.Annotations, 0)
 
-        if len(args)%2 != 0 {
-                err := whisk.MakeWskError(
-                        errors.New("key|value arguments must be submitted in comma-separated pairs"),
-                        whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE )
-                return parsed, err
-        }
+    if len(args)%2 != 0 {
+        err := whisk.MakeWskError(
+            errors.New("key|value arguments must be submitted in comma-separated pairs"),
+            whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE )
+        return parsed, err
+    }
 
-        for i := 0; i < len(args); i += 2 {
-                parsedItem := make(map[string]interface{}, 0)
-                parsedItem["key"] = args[i]
-                parsedItem["value"] = args[i + 1]
-                parsed = append(parsed, parsedItem)
-        }
+    for i := 0; i < len(args); i += 2 {
+        parsedItem := make(map[string]interface{}, 0)
+        parsedItem["key"] = args[i]
+        parsedItem["value"] = args[i + 1]
+        parsed = append(parsed, parsedItem)
+    }
 
-        return parsed, nil
+    return parsed, nil
 }
 
 
 func parseKeyValueArray(args []string) ([]whisk.KeyValue, error) {
-        parsed := []whisk.KeyValue{}
-        if len(args)%2 != 0 {
-                err := whisk.MakeWskError(
-                        errors.New("key|value arguments must be submitted in comma-separated pairs"),
-                        whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE )
-                return parsed, err
-        }
+    parsed := []whisk.KeyValue{}
+    if len(args)%2 != 0 {
+        err := whisk.MakeWskError(
+            errors.New("key|value arguments must be submitted in comma-separated pairs"),
+            whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE )
+        return parsed, err
+    }
 
-        for i := 0; i < len(args); i += 2 {
-                keyValue := whisk.KeyValue{
-                        Key:   args[i],
-                        Value: args[i+1],
-                }
-                parsed = append(parsed, keyValue)
-
+    for i := 0; i < len(args); i += 2 {
+        keyValue := whisk.KeyValue{
+            Key:   args[i],
+            Value: args[i+1],
         }
-        return parsed, nil
+        parsed = append(parsed, keyValue)
+
+    }
+    return parsed, nil
 }
 
 func parseParameters(args []string) (whisk.Parameters, error) {
-        parameters := whisk.Parameters{}
-        parsedArgs, err := parseKeyValueArray(args)
-        if err != nil {
-                return parameters, err
-        }
-        parameters = whisk.Parameters(parsedArgs)
-        return parameters, nil
+    parameters := whisk.Parameters{}
+    parsedArgs, err := parseKeyValueArray(args)
+    if err != nil {
+        return parameters, err
+    }
+    parameters = whisk.Parameters(parsedArgs)
+    return parameters, nil
 }
 
 func parseAnnotations(args []string) (whisk.Annotations, error) {
-        annotations := whisk.Annotations{}
-        //parsedArgs, err := parseKeyValueArray(args)
+    annotations := whisk.Annotations{}
+    //parsedArgs, err := parseKeyValueArray(args)
 
-        parsedArgs, err := parseGenericArray(args)
-        if err != nil {
-        	return annotations, err
-        }
+    parsedArgs, err := parseGenericArray(args)
+    if err != nil {
+        return annotations, err
+    }
 
-        annotations = whisk.Annotations(parsedArgs)
+    annotations = whisk.Annotations(parsedArgs)
 
-        return annotations, nil
+    return annotations, nil
 }
 
 var boldString = color.New(color.Bold).SprintFunc()
 var boldPrintf = color.New(color.Bold).PrintfFunc()
 
 func printList(collection interface{}) {
-        switch collection := collection.(type) {
-        case []whisk.Action:
-                printActionList(collection)
-        case []whisk.Trigger:
-                printTriggerList(collection)
-        case []whisk.Package:
-                printPackageList(collection)
-        case []whisk.Rule:
-                printRuleList(collection)
-        case []whisk.Namespace:
-                printNamespaceList(collection)
-        case []whisk.Activation:
-                printActivationList(collection)
-        }
+    switch collection := collection.(type) {
+    case []whisk.Action:
+        printActionList(collection)
+    case []whisk.Trigger:
+        printTriggerList(collection)
+    case []whisk.Package:
+        printPackageList(collection)
+    case []whisk.Rule:
+        printRuleList(collection)
+    case []whisk.Namespace:
+        printNamespaceList(collection)
+    case []whisk.Activation:
+        printActivationList(collection)
+    }
+}
+
+func printFullList(collection interface{}) {
+    switch collection := collection.(type) {
+    case []whisk.Action:
+
+    case []whisk.Trigger:
+
+    case []whisk.Package:
+
+    case []whisk.Rule:
+
+    case []whisk.Namespace:
+
+    case []whisk.Activation:
+        printFullActivationList(collection)
+    }
 }
 
 func printActionList(actions []whisk.Action) {
-        boldPrintf("actions\n")
-        for _, action := range actions {
-                publishState := "private"
-                if action.Publish {
-                        publishState = "shared"
-                }
-                fmt.Printf("%-70s%s\n", fmt.Sprintf("/%s/%s", action.Namespace, action.Name), publishState)
+    boldPrintf("actions\n")
+    for _, action := range actions {
+        publishState := "private"
+        if action.Publish {
+            publishState = "shared"
         }
+        fmt.Printf("%-70s%s\n", fmt.Sprintf("/%s/%s", action.Namespace, action.Name), publishState)
+    }
 }
 
 func printTriggerList(triggers []whisk.Trigger) {
-        boldPrintf("triggers\n")
-        for _, trigger := range triggers {
-                publishState := "private"
-                if trigger.Publish {
-                        publishState = "shared"
-                }
-                fmt.Printf("%-70s%s\n", fmt.Sprintf("/%s/%s", trigger.Namespace, trigger.Name), publishState)
+    boldPrintf("triggers\n")
+    for _, trigger := range triggers {
+        publishState := "private"
+        if trigger.Publish {
+            publishState = "shared"
         }
+        fmt.Printf("%-70s%s\n", fmt.Sprintf("/%s/%s", trigger.Namespace, trigger.Name), publishState)
+    }
 }
 
 func printPackageList(packages []whisk.Package) {
-        boldPrintf("packages\n")
-        for _, xPackage := range packages {
-                publishState := "private"
-                if xPackage.Publish {
-                        publishState = "shared"
-                }
-                fmt.Printf("%-70s%s\n", fmt.Sprintf("/%s/%s", xPackage.Namespace, xPackage.Name), publishState)
+    boldPrintf("packages\n")
+    for _, xPackage := range packages {
+        publishState := "private"
+        if xPackage.Publish {
+            publishState = "shared"
         }
+        fmt.Printf("%-70s%s\n", fmt.Sprintf("/%s/%s", xPackage.Namespace, xPackage.Name), publishState)
+    }
 }
 
 func printRuleList(rules []whisk.Rule) {
-        boldPrintf("rules\n")
-        for _, rule := range rules {
-                publishState := "private"
-                if rule.Publish {
-                        publishState = "shared"
-                }
-                fmt.Printf("%-70s%s\n", fmt.Sprintf("/%s/%s", rule.Namespace, rule.Name), publishState)
+    boldPrintf("rules\n")
+    for _, rule := range rules {
+        publishState := "private"
+        if rule.Publish {
+            publishState = "shared"
         }
+        fmt.Printf("%-70s%s\n", fmt.Sprintf("/%s/%s", rule.Namespace, rule.Name), publishState)
+    }
 }
 
 func printNamespaceList(namespaces []whisk.Namespace) {
-        boldPrintf("namespaces\n")
-        for _, namespace := range namespaces {
-                fmt.Printf("%s\n", namespace.Name)
-        }
+    boldPrintf("namespaces\n")
+    for _, namespace := range namespaces {
+        fmt.Printf("%s\n", namespace.Name)
+    }
 }
 
 func printActivationList(activations []whisk.Activation) {
-        boldPrintf("activations\n")
-        for _, activation := range activations {
-                fmt.Printf("%s%20s\n", activation.ActivationID, activation.Name)
-        }
+    boldPrintf("activations\n")
+    for _, activation := range activations {
+        fmt.Printf("%s%20s\n", activation.ActivationID, activation.Name)
+    }
+}
+
+func printFullActivationList(activations []whisk.Activation) {
+    boldPrintf("activations\n")
+    for _, activation := range activations {
+        printJsonNoColor(activation)
+    }
 }
 
 //
@@ -253,7 +299,7 @@ func printActivationList(activations []whisk.Activation) {
 
 func logoText() string {
 
-        logo := `
+    logo := `
 
 __          ___     _     _
 \ \        / / |   (_)   | |
@@ -264,10 +310,21 @@ __          ___     _     _
 
                         `
 
-        return logo
+    return logo
 }
 
 func printJSON(v interface{}) {
-        output, _ := prettyjson.Marshal(v)
-        fmt.Println(string(output))
+    output, _ := prettyjson.Marshal(v)
+    fmt.Println(string(output))
+}
+
+// Same as printJSON, but with coloring disabled.
+func printJsonNoColor(v interface{}) {
+    jsonFormatter := prettyjson.NewFormatter()
+    jsonFormatter.DisabledColor = true
+    output, err := jsonFormatter.Marshal(v)
+    if err != nil && IsDebug() {
+        fmt.Printf("printJsonNoColor: Marshal() failure: %s\n", err)
+    }
+    fmt.Println(string(output))
 }

--- a/tools/go-cli/go-whisk/whisk/info.go
+++ b/tools/go-cli/go-whisk/whisk/info.go
@@ -40,7 +40,7 @@ func (s *InfoService) Get() (*Info, *http.Response, error) {
     ref, err := url.Parse(s.client.Config.Version)
     if err != nil {
         if IsDebug() {
-            fmt.Printf("InfoService.Get: url.Parse error - URL '%s'; err '%s'", s.client.Config.Version, err)
+            fmt.Printf("InfoService.Get: url.Parse error - URL '%s'; err '%s'\n", s.client.Config.Version, err)
         }
         errStr := fmt.Sprintf("Unable to URL parse '%s'; error: %s", s.client.Config.Version, err)
         werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
@@ -52,7 +52,7 @@ func (s *InfoService) Get() (*Info, *http.Response, error) {
     req, err := http.NewRequest("GET", u.String(), nil)
     if err != nil {
         if IsDebug() {
-            fmt.Printf("InfoService.Get: http.NewRequest error - URL GET '%s'; err '%s'", u.String(), err)
+            fmt.Printf("InfoService.Get: http.NewRequest error - URL GET '%s'; err '%s'\n", u.String(), err)
         }
         errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", u.String(), err)
         werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
@@ -60,16 +60,16 @@ func (s *InfoService) Get() (*Info, *http.Response, error) {
     }
 
     if IsDebug() {
-        fmt.Printf("InfoService.Get: Sending HTTP req %#v", req)
+        fmt.Printf("InfoService.Get: Sending HTTP URL '%s'; req %#v\n", req.URL.String(), req)
     }
 
     info := new(Info)
     resp, err := s.client.Do(req, &info)
     if err != nil {
         if IsDebug() {
-            fmt.Printf("InfoService.Get: s.client.Do() error - HTTP req %#v; error '%s'", req, err)
+            fmt.Printf("InfoService.Get: s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
         }
-        errStr := fmt.Sprintf("HTTP GET request failure '%s'; error %s", u.String(), err)
+        errStr := fmt.Sprintf("HTTP GET request failure '%s'; error %s", req.URL.String(), err)
         werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }

--- a/tools/go-cli/go-whisk/whisk/wskerror.go
+++ b/tools/go-cli/go-whisk/whisk/wskerror.go
@@ -16,6 +16,9 @@ limitations under the License.
 
 package whisk
 
+import (
+)
+
 const EXITCODE_ERR_GENERAL      int = 1
 const EXITCODE_ERR_NETWORK      int = 2
 const EXITCODE_ERR_HTTP_RESP    int = 3
@@ -37,10 +40,44 @@ func (e WskError) Error() string {
     return e.RootErr.Error()
 }
 
+// Instantiate a WskError stucture
+// Parameters:
+//  error   - RootErr. object implementing the error interface
+//  int     - ExitCode.  Used if error object does not have an exit code OR if ExitCodeOverride is true
+//  bool    - DisplayMsg.  If true, the error message should be displayed on the console
+//  bool    - DisplayUsage.  If true, the command usage syntax/help should be displayed on the console
+//  bool    - MsgDisplay.  If true, the error message has been displayed on the console
 func MakeWskError (e error, ec int, flags ...bool ) (we *WskError) {
     we = &WskError{RootErr: e, ExitCode: ec, DisplayMsg: false, DisplayUsage: false, MsgDisplayed: false}
     if len(flags) > 0 { we.DisplayMsg = flags[0] }
     if len(flags) > 1 { we.DisplayUsage = flags[1] }
     if len(flags) > 2 { we.MsgDisplayed = flags[2] }
     return we
+}
+
+// Instantiate a WskError stucture
+// Parameters:
+//  error   - RootErr. object implementing the error interface
+//  WskError -WskError being wrappered.  It's exitcode will be used as this WskError's exitcode
+//  int     - ExitCode.  Used if error object does not have an exit code OR if ExitCodeOverride is true
+//  bool    - DisplayMsg.  If true, the error message should be displayed on the console
+//  bool    - DisplayUsage.  If true, the command usage syntax/help should be displayed on the console
+//  bool    - MsgDisplay.  If true, the error message has been displayed on the console
+func MakeWskErrorFromWskError (e error, werr error, ec int, flags ...bool ) (we *WskError) {
+    // Pull exit code from error if it exists
+    var exitCode int
+
+    // Input WskError can be a pointer reference
+    if we, ok := werr.(*WskError); ok {
+        exitCode = we.ExitCode
+    } else {
+        exitCode = ec
+    }
+
+    // If input WskError is NOT a pointer reference, use it
+    if we, ok := werr.(WskError); ok {
+        exitCode = we.ExitCode
+    }
+
+    return MakeWskError(e, exitCode, flags...)
 }


### PR DESCRIPTION
- activation internal command processing returns WskError
- Fixes for missing \n on some trace statements
- Create new method for creating a WskError.  It takes a WskError as a parameter (to reuse its exitcode)
  func MakeWskErrorFromWskError (e error, werr error, ec int, flags ...bool ) (we *WskError)
