### PR TITLE
Add --feed argument support to 'trigger create' command

### DIFF
--- a/tools/go-cli/go-whisk-cli/commands/action.go
+++ b/tools/go-cli/go-whisk-cli/commands/action.go
@@ -233,7 +233,7 @@ var actionInvokeCmd = &cobra.Command{
 
         payload := map[string]interface{}{}
 
-        fmt.Printf("PARAMAS %d", len(flags.common.param))
+        //MWD fmt.Printf("PARAMAS %d", len(flags.common.param))
         if len(flags.common.param) > 0 {
             parameters, err := parseParameters(flags.common.param)
 
@@ -272,11 +272,11 @@ var actionInvokeCmd = &cobra.Command{
         activation, _, err := client.Actions.Invoke(qName.entityName, payload, flags.common.blocking)
         if err != nil {
             if IsDebug() {
-                fmt.Printf("actionInvokeCmd: client.Actions.Invoke(%s, %s, %s)\nerror: %s\n", qName.entityName, payload,
+                fmt.Printf("actionInvokeCmd: client.Actions.Invoke(%s, %s, %t)\nerror: %s\n", qName.entityName, payload,
                     flags.common.blocking, err)
             }
 
-            errMsg := fmt.Sprintf("Unable to invoke action: %s\n", err)
+            errMsg := fmt.Sprintf("Unable to invoke action '%s': %s\n", qName.entityName, err)
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
 

--- a/tools/go-cli/go-whisk-cli/commands/flags.go
+++ b/tools/go-cli/go-whisk-cli/commands/flags.go
@@ -44,6 +44,7 @@ var flags struct {
         limit       int  // return max N records
         full        bool // return full records (docs=true for client request)
         summary     bool
+        feed        string  // name of feed
    }
 
     property struct {


### PR DESCRIPTION
Add --feed argument support to 'trigger create' command
Fixes 'Wsk Trigger CLI should not create a trigger when feed fails to initialize' unit test
