### PR TITLE
Refactor tracing to use Whisk.Debug()

### DIFF
--- a/tools/go-cli/go-whisk-cli/commands/activation.go
+++ b/tools/go-cli/go-whisk-cli/commands/activation.go
@@ -49,29 +49,24 @@ var activationListCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         qName := qualifiedName{}
+
+        // Specifying an activation item name filter is optional
         if len(args) == 1 {
-            if IsDebug() {
-                fmt.Printf("activationListCmd: namespace argument '%#v' is provided\n", args[0])
-            }
+            whisk.Debug(whisk.DbgInfo, "Activation item name filter '%s' provided\n", args[0])
             qName, err = parseQualifiedName(args[0])
             if err != nil {
-                if IsDebug() {
-                    fmt.Printf("activationListCmd: parseQualifiedName(%#v) error: %s\n", args[0], err)
-                }
+                whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
                 errStr := fmt.Sprintf("'%s' is not a valid qualified name: %s", args[0], err)
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
             ns := qName.namespace
             if len(ns) == 0 {
-                if IsDebug() {
-                    fmt.Printf("activationListCmd: Namespace '%s' is invalid\n", ns)
-                }
+                whisk.Debug(whisk.DbgError, "Namespace '%s' is invalid\n", ns)
                 errStr := fmt.Sprintf("Namespace '%s' is invalid", ns)
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }
-
             client.Namespace = ns
 
             if pkg := qName.packageName; len(pkg) > 0 {
@@ -89,9 +84,7 @@ var activationListCmd = &cobra.Command{
         }
         activations, _, err := client.Activations.List(options)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("activationListCmd: client.Activations.List() error: %s\n", err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Activations.List() error: %s\n", err)
             errStr := fmt.Sprintf("Unable to obtain list of activations: %s", err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -115,9 +108,7 @@ var activationGetCmd = &cobra.Command{
     SilenceErrors:  true,
     RunE: func(cmd *cobra.Command, args []string) error {
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("activationGetCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -125,9 +116,7 @@ var activationGetCmd = &cobra.Command{
         id := args[0]
         activation, _, err := client.Activations.Get(id)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("activationGetCmd: client.Activations.Get(%s) failed: %s\n", id, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Activations.Get(%s) failed: %s\n", id, err)
             errStr := fmt.Sprintf("Unable to obtain activation record for '%s': %s", id, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -153,9 +142,7 @@ var activationLogsCmd = &cobra.Command{
     SilenceErrors:  true,
     RunE: func(cmd *cobra.Command, args []string) error {
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("activationLogsCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -164,9 +151,7 @@ var activationLogsCmd = &cobra.Command{
         id := args[0]
         activation, _, err := client.Activations.Logs(id)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("activationLogsCmd: client.Activations.Logs(%s) failed: %s\n", id, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Activations.Logs(%s) failed: %s\n", id, err)
             errStr := fmt.Sprintf("Unable to obtain logs for activation '%s': %s", id, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -184,9 +169,7 @@ var activationResultCmd = &cobra.Command{
     SilenceErrors:  true,
     RunE: func(cmd *cobra.Command, args []string) error {
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("activationResultCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -195,9 +178,7 @@ var activationResultCmd = &cobra.Command{
         id := args[0]
         result, _, err := client.Activations.Result(id)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("activationResultCmd: client.Activations.result(%s) failed: %s\n", id, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Activations.result(%s) failed: %s\n", id, err)
             errStr := fmt.Sprintf("Unable to obtain result information for activation '%s': %s", id, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -218,6 +199,8 @@ var activationPollCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var name string
         var pollSince int64 // Represents an instant in time (in milliseconds since Jan 1 1970)
+
+        // The activation item filter is optional
         if len(args) == 1 {
             name = args[0]
         }
@@ -246,11 +229,9 @@ var activationPollCmd = &cobra.Command{
             }
             activationList, _, err := client.Activations.List(options)
             if err != nil {
-                if IsDebug() {
-                    fmt.Printf("activationPollCmd: Warning! client.Activations.List() error: %s\n", err)
-                    fmt.Println("activationPollCmd: Ignoring client.Activations.List failure; polling for activations since 'now'")
-                    pollSince = time.Now().Unix() * 1000    // Convert to milliseconds
-                }
+                whisk.Debug(whisk.DbgWarn, "client.Activations.List() error: %s\n", err)
+                whisk.Debug(whisk.DbgWarn, "Ignoring client.Activations.List failure; polling for activations since 'now'\n")
+                pollSince = time.Now().Unix() * 1000    // Convert to milliseconds
             } else {
                 if len(activationList) > 0 {
                     lastActivation := activationList[0]     // Activation.Start is in milliseconds since Jan 1 1970
@@ -270,9 +251,7 @@ var activationPollCmd = &cobra.Command{
             if err == nil {
                 pollSince = pollSince - duration.Nanoseconds()/1000/1000    // Convert to milliseconds
             } else {
-                if IsDebug() {
-                    fmt.Printf("activationPollCmd: time.ParseDuration(%s) failure: %s\n", durationStr, err)
-                }
+                whisk.Debug(whisk.DbgError, "time.ParseDuration(%s) failure: %s\n", durationStr, err)
             }
         }
 
@@ -285,9 +264,7 @@ var activationPollCmd = &cobra.Command{
             if flags.activation.exit > 0 {
                 localDuration := time.Since(localStartTime)
                 if int(localDuration.Seconds()) > flags.activation.exit {
-                    if IsDebug() {
-                        fmt.Printf("activationPollCmd: Poll time (%d seconds) expired; polling loop stopped\n", flags.activation.exit)
-                    }
+                    whisk.Debug(whisk.DbgInfo, "Poll time (%d seconds) expired; polling loop stopped\n", flags.activation.exit)
                     return nil
                 }
             }
@@ -304,10 +281,8 @@ var activationPollCmd = &cobra.Command{
 
             activations, _, err := client.Activations.List(options)
             if err != nil {
-                if IsDebug() {
-                    fmt.Printf("activationPollCmd: Warning! client.Activations.List() error: %s\n", err)
-                    fmt.Println("activationPollCmd: Ignoring client.Activations.List failure; continuing to poll for activations")
-                }
+                whisk.Debug(whisk.DbgWarn, "client.Activations.List() error: %s\n", err)
+                whisk.Debug(whisk.DbgWarn, "Ignoring client.Activations.List failure; continuing to poll for activations\n")
                 continue
             }
 

--- a/tools/go-cli/go-whisk-cli/commands/namespace.go
+++ b/tools/go-cli/go-whisk-cli/commands/namespace.go
@@ -42,9 +42,7 @@ var namespaceListCmd = &cobra.Command{
 
         namespaces, _, err := client.Namespaces.List()
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("namespaceListCmd: client.Namespaces.List() error: %s\n", err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Namespaces.List() error: %s\n", err)
             errStr := fmt.Sprintf("Unable to obtain list of available namspaces: %s", err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -63,29 +61,21 @@ var namespaceGetCmd = &cobra.Command{
         var qName qualifiedName
         var err error
 
+        // Namespace argument is optional; defaults to configured property namespace
         if (len(args) == 1) {
             qName, err = parseQualifiedName(args[0])
-
             if err != nil {
-
-                if IsDebug() {
-                    fmt.Println("namespaceGetCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-                }
-
+                whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
                 errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
-                whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
-                return whiskErr
+                return werr
             }
         }
 
         namespace, _, err := client.Namespaces.Get(qName.namespace)
-
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("namespaceGetCmd: client.Namespaces.Get(%s) error: %s\n", qName.namespace, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Namespaces.Get(%s) error: %s\n", qName.namespace, err)
             errStr := fmt.Sprintf("Unable to obtain namespace entities for namespace '%s': %s", qName.namespace, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -109,7 +99,7 @@ var namespaceGetCmd = &cobra.Command{
     },
 }
 
-// listCmd is a shortcut for "wsk namespace get _"
+// listCmd ("wsk list") is a shortcut for "wsk namespace get _"
 var listCmd = &cobra.Command{
     Use:   "list <namespace string>",
     Short: "list triggers, actions, and rules in the registry for a namespace",

--- a/tools/go-cli/go-whisk-cli/commands/package.go
+++ b/tools/go-cli/go-whisk-cli/commands/package.go
@@ -76,9 +76,7 @@ var packageBindCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         if len(args) != 2 {
-            if IsDebug() {
-                fmt.Printf("packageBindCmd: Invalid number of arguments %d; args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d; args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; either the package name or the binding name is missing", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -87,9 +85,7 @@ var packageBindCmd = &cobra.Command{
         packageName := args[0]
         pkgQName, err := parseQualifiedName(packageName)
         if err != nil {
-            if IsDebug() {
-                fmt.Println("packageBindCmd: parseQualifiedName(%s)\nerror: %s\n", packageName, err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", packageName, err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", packageName)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -99,28 +95,20 @@ var packageBindCmd = &cobra.Command{
         bindingName := args[1]
         bindQName, err := parseQualifiedName(bindingName)
         if err != nil {
-            if IsDebug() {
-                fmt.Println("packageBindCmd: parseQualifiedName(%s)\nerror: %s\n", bindingName, err)
-            }
-
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", bindingName, err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", bindingName)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
             return werr
         }
 
         // Convert the binding's list of default parameters from a string into []KeyValue
         // The 1 or more --param arguments have all been combined into a single []string
         // e.g.   --p arg1,arg2 --p arg3,arg4   ->  [arg1, arg2, arg3, arg4]
-        if IsDebug() {
-            fmt.Printf("packageBindCmd: parsing parameters: %#v\n", flags.common.param)
-        }
+        whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
         parameters, err := parseParameters(flags.common.param)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageBindCmd: parseParameters(%#v) failed: %s\n", flags.common.param, err)
-            }
+            whisk.Debug(whisk.DbgError, "parseParameters(%#v) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -129,15 +117,11 @@ var packageBindCmd = &cobra.Command{
         // Convert the binding's list of default annotations from a string into []KeyValue
         // The 1 or more --annotation arguments have all been combined into a single []string
         // e.g.   --a arg1,arg2 --a arg3,arg4   ->  [arg1, arg2, arg3, arg4]
-        if IsDebug() {
-            fmt.Printf("packageBindCmd: parsing annotations: %#v\n", flags.common.annotation)
-        }
+        whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
         annotations, err := parseAnnotations(flags.common.annotation)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageBindCmd: parseParameters(%#v) failed: %s\n", flags.common.annotation, err)
-            }
-            errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.annotation, err)
+            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+            errStr := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -156,9 +140,7 @@ var packageBindCmd = &cobra.Command{
 
         _,  _, err = client.Packages.Insert(p, false)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageBindCmd: client.Packages.Insert(%#v, false) failed: %s\n", p, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Packages.Insert(%#v, false) failed: %s\n", p, err)
             errStr := fmt.Sprintf("Binding creation failed: %s", err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -179,9 +161,7 @@ var packageCreateCmd = &cobra.Command{
         var shared, sharedSet bool
 
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("packageCreateCmd: Invalid number of arguments %d (expected 1 argument); args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d (expected 1 argument); args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; the package name is the only expected argument", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -189,15 +169,12 @@ var packageCreateCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("packageCreateCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-
         client.Namespace = qName.namespace
 
         if (flags.common.shared == "yes") {
@@ -210,25 +187,20 @@ var packageCreateCmd = &cobra.Command{
             sharedSet = false
         }
 
-        if IsDebug() {
-            fmt.Printf("packageCreateCmd: raw parameters: %#v\n", flags.common.param)
-        }
+        whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
         parameters, err := parseParameters(flags.common.param)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageCreateCmd: parseParameters(%#v) failed: %s\n", flags.common.param, err)
-            }
+            whisk.Debug(whisk.DbgError, "parseParameters(%#v) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
 
+        whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
         annotations, err := parseAnnotations(flags.common.annotation)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageCreateCmd: parseParameters(%#v) failed: %s\n", flags.common.annotation, err)
-            }
-            errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.annotation, err)
+            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+            errStr := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -254,9 +226,7 @@ var packageCreateCmd = &cobra.Command{
 
         p, _, err = client.Packages.Insert(p, false)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageCreateCmd: client.Packages.Insert(%#v, false) failed: %s\n", p, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Packages.Insert(%#v, false) failed: %s\n", p, err)
             errStr := fmt.Sprintf("Package creation failed: %s", err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -310,9 +280,7 @@ var packageUpdateCmd = &cobra.Command{
         var shared, sharedSet bool
 
         if len(args) < 1 {
-            if IsDebug() {
-                fmt.Printf("packageUpdateCmd: Invalid number of arguments %d (expected 1 argument); args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d (expected 1 argument); args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; the package name is the only expected argument", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -320,9 +288,7 @@ var packageUpdateCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("packageUpdateCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -340,22 +306,20 @@ var packageUpdateCmd = &cobra.Command{
             sharedSet = false
         }
 
+        whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
         parameters, err := parseParameters(flags.common.param)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageUpdateCmd: parseParameters(%#v) failed: %s\n", flags.common.param, err)
-            }
+            whisk.Debug(whisk.DbgError, "parseParameters(%#v) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
 
+        whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
         annotations, err := parseAnnotations(flags.common.annotation)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageUpdateCmd: parseParameters(%#v) failed: %s\n", flags.common.annotation, err)
-            }
-            errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.annotation, err)
+            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+            errStr := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -381,9 +345,7 @@ var packageUpdateCmd = &cobra.Command{
 
         p, _, err = client.Packages.Insert(p, true)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageUpdateCmd: client.Packages.Insert(%#v, true) failed: %s\n", p, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Packages.Insert(%#v, true) failed: %s\n", p, err)
             errStr := fmt.Sprintf("Package update failed: %s", err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -403,9 +365,7 @@ var packageGetCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("packageGetCmd: Invalid number of arguments %d (expected 1 argument); args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d (expected 1 argument); args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; the package name is the only expected argument", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -413,9 +373,7 @@ var packageGetCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("packageGetCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -425,9 +383,7 @@ var packageGetCmd = &cobra.Command{
 
         xPackage, _, err := client.Packages.Get(qName.entityName)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageGetCmd: client.Packages.Get(%s) failed: %s\n", qName.entityName, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Packages.Get(%s) failed: %s\n", qName.entityName, err)
             errStr := fmt.Sprintf("Package update failed: %s", err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -455,9 +411,7 @@ var packageDeleteCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("packageDeleteCmd: Invalid number of arguments %d (expected 1 argument); args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d (expected 1 argument); args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; the package name is the only expected argument", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -465,22 +419,17 @@ var packageDeleteCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("packageDeleteCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-
         client.Namespace = qName.namespace
 
         _, err = client.Packages.Delete(qName.entityName)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageDeleteCmd: client.Packages.Delete(%s) failed: %s\n", qName.entityName, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Packages.Delete(%s) failed: %s\n", qName.entityName, err)
             errStr := fmt.Sprintf("Package delete failed: %s", err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -505,9 +454,7 @@ var packageListCmd = &cobra.Command{
         if len(args) == 1 {
             qName, err = parseQualifiedName(args[0])
             if err != nil {
-                if IsDebug() {
-                    fmt.Println("packageListCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-                }
+                whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
                 errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -515,9 +462,7 @@ var packageListCmd = &cobra.Command{
             }
             ns := qName.namespace
             if len(ns) == 0 {
-                if IsDebug() {
-                    fmt.Printf("packageListCmd: An empty namespace in the package name '%s' is invalid \n", args[0])
-                }
+                whisk.Debug(whisk.DbgError, "An empty namespace in the package name '%s' is invalid \n", args[0])
                 errStr := fmt.Sprintf("No valid namespace detected.  Make sure that namespace argument is preceded by a \"/\"")
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
@@ -541,9 +486,7 @@ var packageListCmd = &cobra.Command{
 
         packages, _, err := client.Packages.List(options)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageListCmd: client.Packages.List(%+v) failed: %s\n", options, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Packages.List(%+v) failed: %s\n", options, err)
             errStr := fmt.Sprintf("Unable to obtain package list: %s", err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -573,17 +516,12 @@ var packageRefreshCmd = &cobra.Command{
 
         updates, resp, err := client.Packages.Refresh()
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("packageRefreshCmd: client.Packages.List() of namespace '%s' failed: %s\n", client.Config.Namespace, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Packages.Refresh() of namespace '%s' failed: %s\n", client.Config.Namespace, err)
             errStr := fmt.Sprintf("Package refresh for namespace '%s' failed: %s", client.Config.Namespace, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-
-        if IsDebug() {
-            fmt.Printf("packageRefreshCmd: Refresh updates received: %#v\n", updates)
-        }
+        whisk.Debug(whisk.DbgInfo, "Refresh updates received: %#v\n", updates)
 
         switch resp.StatusCode {
         case http.StatusOK:
@@ -614,16 +552,12 @@ var packageRefreshCmd = &cobra.Command{
             }
 
         case http.StatusNotImplemented:
-            if IsDebug() {
-                fmt.Printf("packageRefreshCmd: client.Packages.List() returned 'Not Implemented' HTTP status code: %d\n", resp.StatusCode)
-            }
+            whisk.Debug(whisk.DbgError, "client.Packages.Refresh() for namespace '%s' returned 'Not Implemented' HTTP status code: %d\n", client.Config.Namespace, resp.StatusCode)
             errStr := fmt.Sprintf("The package refresh feature is not implement in the target deployment")
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         default:
-            if IsDebug() {
-                fmt.Printf("packageRefreshCmd: client.Packages.List() for namespace '%s' returned an unexpected HTTP status code: %d\n",  client.Config.Namespace, resp.StatusCode)
-            }
+            whisk.Debug(whisk.DbgError, "client.Packages.Refresh() for namespace '%s' returned an unexpected HTTP status code: %d\n",  client.Config.Namespace, resp.StatusCode)
             errStr := fmt.Sprintf("Package refresh for namespace '%s' failed due to unexpected HTTP status code: %d",  client.Config.Namespace, resp.StatusCode)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -69,7 +69,7 @@ var propertySetCmd = &cobra.Command{
         props, err := readProps(Properties.PropsFile)
         if err != nil {
             whisk.Debug(whisk.DbgError, "readProps(%s) failed: %s\n", Properties.PropsFile, err)
-            errStr := fmt.Sprintf("Unable to set the property value: %s\n", err)
+            errStr := fmt.Sprintf("Unable to set the property value: %s", err)
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }

--- a/tools/go-cli/go-whisk-cli/commands/rule.go
+++ b/tools/go-cli/go-whisk-cli/commands/rule.go
@@ -41,9 +41,7 @@ var ruleEnableCmd = &cobra.Command{
 
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("ruleEnableCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -51,19 +49,14 @@ var ruleEnableCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("ruleEnableCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
-            return whiskErr
+            return werr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("ruleEnableCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -73,13 +66,12 @@ var ruleEnableCmd = &cobra.Command{
 
         _, _, err = client.Rules.SetState(ruleName, "active")
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("ruleEnableCmd: client.Rules.SetState(%s, active) failed: %s\n", ruleName, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Rules.SetState(%s, active) failed: %s\n", ruleName, err)
             errStr := fmt.Sprintf("Unable to enable rule '%s': %s", ruleName, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
+
         fmt.Printf("%s enabled rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
     },
@@ -94,9 +86,7 @@ var ruleDisableCmd = &cobra.Command{
 
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("ruleDisableCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -104,36 +94,29 @@ var ruleDisableCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("ruleEnableCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
-            return whiskErr
+            return werr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("ruleEnableCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        //MWD ruleName := args[0]
 
         _, _, err = client.Rules.SetState(ruleName, "inactive")
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("ruleDisableCmd: client.Rules.SetState(%s, inactive) failed: %s\n", ruleName, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Rules.SetState(%s, inactive) failed: %s\n", ruleName, err)
             errStr := fmt.Sprintf("Unable to disable rule '%s': %s", ruleName, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
+
         fmt.Printf("%s disabled rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
     },
@@ -147,9 +130,7 @@ var ruleStatusCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("ruleStatusCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -157,36 +138,29 @@ var ruleStatusCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("ruleEnableCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
-            return whiskErr
+            return werr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("ruleEnableCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        //MWD ruleName := args[0]
 
         rule, _, err := client.Rules.Get(ruleName)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("ruleStatusCmd: client.Rules.Get(%s) failed: %s\n", ruleName, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Rules.Get(%s) failed: %s\n", ruleName, err)
             errStr := fmt.Sprintf("Unable to retrieve rule '%s': %s", ruleName, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
+
         fmt.Printf("%s rule %s is %s\n", color.GreenString("ok:"), boldString(ruleName), boldString(rule.Status))
         return nil
     },
@@ -202,9 +176,7 @@ var ruleCreateCmd = &cobra.Command{
         var shared bool
 
         if len(args) != 3 {
-            if IsDebug() {
-                fmt.Printf("ruleCreateCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly three arguments are expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -218,28 +190,22 @@ var ruleCreateCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("ruleEnableCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
-            return whiskErr
+            return werr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("ruleEnableCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        //MWD ruleName := args[0]
-        triggerName := args[1]
-        actionName := args[2]
+        triggerName := args[1]  // MWD qualified name here?
+        actionName := args[2]   // MWD qualified name here?
 
         rule := &whisk.Rule{
             Name:    ruleName,
@@ -248,39 +214,28 @@ var ruleCreateCmd = &cobra.Command{
             Publish: shared,
         }
 
-        if IsDebug() {
-            fmt.Printf("ruleCreateCmd: Inserting rule:\n%+v\n", rule)
-        }
-
+        whisk.Debug(whisk.DbgInfo, "Inserting rule:\n%+v\n", rule)
         var retRule *whisk.Rule
         retRule, _, err = client.Rules.Insert(rule, false)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("ruleCreateCmd: client.Rules.Insert(%#v) failed: %s\n", rule, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Rules.Insert(%#v) failed: %s\n", rule, err)
             errStr := fmt.Sprintf("Unable to create rule '%s': %s", rule.Name, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-        if IsDebug() {
-            fmt.Printf("ruleCreateCmd: Inserted rule:\n%+v\n", retRule)
-        }
+        whisk.Debug(whisk.DbgInfo, "Inserted rule:\n%+v\n", retRule)
 
         if flags.rule.enable {
             retRule, _, err = client.Rules.SetState(ruleName, "active")
             if err != nil {
-                if IsDebug() {
-                    fmt.Printf("ruleCreateCmd: client.Rules.SetState(%s, active) failed: %s\n", ruleName, err)
-                }
+                whisk.Debug(whisk.DbgError, "client.Rules.SetState(%s, active) failed: %s\n", ruleName, err)
                 // MWD - Is this a hard error since the rule was actually created
                 errStr := fmt.Sprintf("Unable to enable created rule '%s': %s", rule.Name, err)
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
         }
-        if IsDebug() {
-            fmt.Printf("ruleCreateCmd: Enabled rule:\n%+v\n", retRule)
-        }
+        whisk.Debug(whisk.DbgInfo, "Enabled rule:\n%+v\n", retRule)
 
         fmt.Printf("%s created rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
@@ -297,9 +252,7 @@ var ruleUpdateCmd = &cobra.Command{
         var shared bool
 
         if len(args) != 3 {
-            if IsDebug() {
-                fmt.Printf("ruleGetCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly three arguments are expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -307,28 +260,22 @@ var ruleUpdateCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("ruleEnableCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
-            return whiskErr
+            return werr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("ruleEnableCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        //MWD ruleName := args[0]
-        triggerName := args[1]
-        actionName := args[2]
+        triggerName := args[1]  //MWD qualified name?
+        actionName := args[2]   //MWD qualified name?
 
         if (flags.common.shared == "yes") {
             shared = true
@@ -345,13 +292,12 @@ var ruleUpdateCmd = &cobra.Command{
 
         rule, _, err = client.Rules.Insert(rule, true)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("ruleCreateCmd: client.Rules.Insert(%#v) failed: %s\n", rule, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Rules.Insert(%#v) failed: %s\n", rule, err)
             errStr := fmt.Sprintf("Unable to update rule '%s': %s", rule.Name, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
+
         fmt.Printf("%s updated rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
     },
@@ -365,9 +311,7 @@ var ruleGetCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("ruleGetCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -375,36 +319,29 @@ var ruleGetCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("ruleEnableCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
-            return whiskErr
+            return werr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("ruleEnableCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        //MWD ruleName := args[0]
 
         rule, _, err := client.Rules.Get(ruleName)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("ruleGetCmd: client.Rules.Get(%s) failed: %s\n", ruleName, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Rules.Get(%s) failed: %s\n", ruleName, err)
             errStr := fmt.Sprintf("Unable to retrieve rule '%s': %s", ruleName, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
+
         fmt.Printf("%s got rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         printJSON(rule)
         return nil
@@ -419,9 +356,7 @@ var ruleDeleteCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("ruleDeleteCmd: Invalid number of arguments: %d\n", len(args))
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -429,33 +364,25 @@ var ruleDeleteCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("ruleEnableCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
-            return whiskErr
+            return werr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("ruleEnableCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        //MWD ruleName := args[0]
 
         if flags.rule.disable {
             _, _, err := client.Rules.SetState(ruleName, "inactive")
             if err != nil {
-                if IsDebug() {
-                    fmt.Printf("ruleDeleteCmd: client.Rules.SetState(%s, inactive) failed: %s\n", ruleName, err)
-                }
+                whisk.Debug(whisk.DbgError, "client.Rules.SetState(%s, inactive) failed: %s\n", ruleName, err)
                 errStr := fmt.Sprintf("Unable to disable rule '%s': %s", ruleName, err)
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
@@ -464,13 +391,12 @@ var ruleDeleteCmd = &cobra.Command{
 
         _, err = client.Rules.Delete(ruleName)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("ruleDeleteCmd: client.Rules.Delete(%s) error: %s\n", ruleName, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Rules.Delete(%s) error: %s\n", ruleName, err)
             errStr := fmt.Sprintf("Unable to delete rule '%s': %s", ruleName, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
+
         fmt.Printf("%s deleted rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
     },
@@ -487,23 +413,18 @@ var ruleListCmd = &cobra.Command{
         if len(args) == 1 {
             qName, err = parseQualifiedName(args[0])
             if err != nil {
-                if IsDebug() {
-                    fmt.Printf("ruleListCmd: parseQualifiedName(%#v) error: %s\n", args[0], err)
-                }
+                whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
                 errStr := fmt.Sprintf("'%s' is not a valid qualified name: %s", args[0], err)
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
             ns := qName.namespace
             if len(ns) == 0 {
-                if IsDebug() {
-                    fmt.Printf("ruleListCmd: Namespace is missing from '%s'\n", args[0])
-                }
+                whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
                 errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }
-
             client.Namespace = ns
 
             if pkg := qName.packageName; len(pkg) > 0 {
@@ -518,9 +439,7 @@ var ruleListCmd = &cobra.Command{
 
         rules, _, err := client.Rules.List(ruleListOptions)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("ruleListCmd: client.Rules.List(%#v) error: %s\n", ruleListOptions, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Rules.List(%#v) error: %s\n", ruleListOptions, err)
             errStr := fmt.Sprintf("Unable to obtain list of rules: %s", err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr

--- a/tools/go-cli/go-whisk-cli/commands/sdk.go
+++ b/tools/go-cli/go-whisk-cli/commands/sdk.go
@@ -153,7 +153,7 @@ func sdkInstall(componentName string) error {
     sdkfile, err := os.Create(targetFile)
     if err != nil {
         whisk.Debug(whisk.DbgError, "os.Create(%s) failure: %s\n", targetFile, err)
-        errStr := fmt.Sprintf("Error creating SDK file %s: %s\n", targetFile, err)
+        errStr := fmt.Sprintf("Error creating SDK file %s: %s", targetFile, err)
         werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -163,7 +163,7 @@ func sdkInstall(componentName string) error {
     _, err = io.Copy(sdkfile, resp.Body)
     if err != nil {
         whisk.Debug(whisk.DbgError, "io.Copy() of resp.Body into sdkfile failure: %s\n", err)
-        errStr := fmt.Sprintf("Error copying response body into file: %s\n", err)
+        errStr := fmt.Sprintf("Error copying response body into file: %s", err)
         werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         sdkfile.Close()
         return werr
@@ -192,7 +192,7 @@ func sdkInstall(componentName string) error {
             err := unpackGzip(targetFile, "temp.tar")
             if err != nil {
                 whisk.Debug(whisk.DbgError, "unpackGzip(%s,temp.tar) failure: %s\n", targetFile, err)
-                errStr := fmt.Sprintf("Error unGziping file %s: %s\n", targetFile, err)
+                errStr := fmt.Sprintf("Error unGziping file %s: %s", targetFile, err)
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
@@ -202,7 +202,7 @@ func sdkInstall(componentName string) error {
             err = unpackTar("temp.tar")
             if err != nil {
                 whisk.Debug(whisk.DbgError, "unpackTar(temp.tar) failure: %s\n", err)
-                errStr := fmt.Sprintf("Error Error untaring file %s: %s\n", "temp.tar", err)
+                errStr := fmt.Sprintf("Error untaring file %s: %s", "temp.tar", err)
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }

--- a/tools/go-cli/go-whisk-cli/commands/trigger.go
+++ b/tools/go-cli/go-whisk-cli/commands/trigger.go
@@ -43,9 +43,7 @@ var triggerFireCmd = &cobra.Command{
         var err error
         var payloadArg string
         if len(args) < 1 || len(args) > 2 {
-            if IsDebug() {
-                fmt.Printf("triggerFireCmd: Invalid number of arguments %d (expected 1 or 2); args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d (expected 1 or 2); args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; 1 or 2 arguments are expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -53,10 +51,7 @@ var triggerFireCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("triggerFireCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
-
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -64,9 +59,7 @@ var triggerFireCmd = &cobra.Command{
             return whiskErr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("triggerFireCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -78,9 +71,7 @@ var triggerFireCmd = &cobra.Command{
         if len(flags.common.param) > 0 {
             parameters, err := parseParameters(flags.common.param)
             if err != nil {
-                if IsDebug() {
-                    fmt.Printf("triggerFireCmd: parseParameters(%#v) failed: %s\n", flags.common.param, err)
-                }
+                whisk.Debug(whisk.DbgError, "parseParameters(%#v) failed: %s\n", flags.common.param, err)
                 errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
@@ -97,19 +88,14 @@ var triggerFireCmd = &cobra.Command{
             err = json.NewDecoder(reader).Decode(&payload)
             if err != nil {
                 payload["payload"] = payloadArg
-
-                if IsDebug() {
-                    fmt.Printf("triggerFireCmd: json.NewDecoder().Decode() failure decoding '%s': : %s\n", payloadArg, err)
-                    fmt.Printf("triggerFireCmd: Defaulting payload to %#v\n", payload)
-                }
+                whisk.Debug(whisk.DbgError, "json.NewDecoder().Decode() failure decoding '%s': : %s\n", payloadArg, err)
+                whisk.Debug(whisk.DbgWarn, "Defaulting payload to %#v\n", payload)
             }
         }
 
         trigResp, _, err := client.Triggers.Fire(qName.entityName, payload)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerFireCmd: client.Triggers.Fire(%s, %#v) failed: %s\n", qName.entityName, payload, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Triggers.Fire(%s, %#v) failed: %s\n", qName.entityName, payload, err)
             errStr := fmt.Sprintf("Unable to fire trigger '%s': %s", qName.entityName, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -132,9 +118,7 @@ var triggerCreateCmd = &cobra.Command{
         var feedParams []string
 
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: Invalid number of arguments %d; args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d; args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -142,20 +126,14 @@ var triggerCreateCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("triggerCreateCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
-
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
             return whiskErr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -165,14 +143,10 @@ var triggerCreateCmd = &cobra.Command{
         // Convert the trigger's list of default parameters from a string into []KeyValue
         // The 1 or more --param arguments have all been combined into a single []string
         // e.g.   --p arg1,arg2 --p arg3,arg4   ->  [arg1, arg2, arg3, arg4]
-        if IsDebug() {
-            fmt.Printf("triggerCreateCmd: parsing parameters: %#v\n", flags.common.param)
-        }
+        whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
         parameters, err := parseParameters(flags.common.param)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: parseParameters(%#v) failed: %s\n", flags.common.param, err)
-            }
+            whisk.Debug(whisk.DbgError, "parseParameters(%#v) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -181,23 +155,17 @@ var triggerCreateCmd = &cobra.Command{
         var fullTriggerName string
         var fullFeedName string
         if feedArgPassed {
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: trigger has a feed\n")
-            }
+            whisk.Debug(whisk.DbgInfo, "Trigger has a feed\n")
             feedqName, err := parseQualifiedName(flags.common.feed)
             if err != nil {
-                if IsDebug() {
-                    fmt.Println("triggerCreateCmd: parseQualifiedName(%s)\nerror: %s\n", flags.common.feed, err)
-                }
+                whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", flags.common.feed, err)
                 errMsg := fmt.Sprintf("Failed to parse qualified feed name: %s\n", flags.common.feed)
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return whiskErr
             }
             if len(feedqName.namespace) == 0 {
-                if IsDebug() {
-                    fmt.Printf("triggerCreateCmd: Namespace is missing from '%s'\n", flags.common.feed)
-                }
+                whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", flags.common.feed)
                 errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
@@ -218,20 +186,13 @@ var triggerCreateCmd = &cobra.Command{
             feedParams = append(feedParams, flags.global.auth)  // MWD ?? only from CLI arg
 
             parameters = whisk.Parameters{}
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: trigger feed action parameters: %#v\n", feedParams)
-            }
-
+            whisk.Debug(whisk.DbgInfo, "Trigger feed action parameters: %#v\n", feedParams)
         }
 
-        if IsDebug() {
-            fmt.Printf("triggerCreateCmd: parsing annotations: %#v\n", flags.common.annotation)
-        }
+        whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
         annotations, err := parseAnnotations(flags.common.annotation)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
-            }
+            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
             errStr := fmt.Sprintf("Invalid annotations argument value '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -241,20 +202,13 @@ var triggerCreateCmd = &cobra.Command{
             feedAnnotation["key"] = "feed"
             feedAnnotation["value"] = flags.common.feed
             annotations = append(annotations, feedAnnotation)
-
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: trigger feed annotations: %#v\n", annotations)
-            }
+            whisk.Debug(whisk.DbgInfo, "Trigger feed annotations: %#v\n", annotations)
         }
 
-        if IsDebug() {
-            fmt.Printf("triggerCreateCmd: trigger shared: %s\n", flags.common.shared)
-        }
+        whisk.Debug(whisk.DbgInfo, "Trigger shared: %s\n", flags.common.shared)
         shared := strings.ToLower(flags.common.shared)
         if shared != "yes" && shared != "no" && shared != "" {  // "" means argument was not specified
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: shared argument value '%s' is invalid\n", flags.common.shared)
-            }
+            whisk.Debug(whisk.DbgError, "Shared argument value '%s' is invalid\n", flags.common.shared)
             errStr := fmt.Sprintf("Invalid --shared argument value '%s'; valid values are 'yes' or 'no'", flags.common.shared)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), nil, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -273,9 +227,7 @@ var triggerCreateCmd = &cobra.Command{
 
         retTrigger, _, err := client.Triggers.Insert(trigger, false)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: client.Triggers.Insert(%+v,false) failed: %s\n", trigger, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Triggers.Insert(%+v,false) failed: %s\n", trigger, err)
             errStr := fmt.Sprintf("Unable to create trigger '%s': %s", trigger.Name, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -285,23 +237,18 @@ var triggerCreateCmd = &cobra.Command{
         if feedArgPassed {
             err := createFeed(trigger.Name, fullFeedName, feedParams)
             if err != nil {
-                if IsDebug() {
-                    fmt.Printf("triggerCreateCmd: createFeed(%s, %s, %+v) failed: %s\n", trigger.Name, flags.common.feed, feedParams, err)
-                }
+                whisk.Debug(whisk.DbgError, "createFeed(%s, %s, %+v) failed: %s\n", trigger.Name, flags.common.feed, feedParams, err)
                 errStr := fmt.Sprintf("Unable to create trigger '%s': %s", trigger.Name, err)
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
 
                 // Delete trigger that was created for this feed
                 delerr := deleteTrigger(args[0])
                 if delerr != nil {
-                    if IsDebug() {
-                        fmt.Printf("triggerCreateCmd: warning - ignoring deleteTrigger(%s) failure: %s\n", args[0], delerr)
-                    }
+                    whisk.Debug(whisk.DbgWarn, "Ignoring deleteTrigger(%s) failure: %s\n", args[0], delerr)
                 }
                 return werr
             }
         }
-
 
         fmt.Println("ok: created trigger")
         //MWD printJSON(retTrigger) // color does appear correctly on vagrant VM
@@ -319,9 +266,7 @@ var triggerUpdateCmd = &cobra.Command{
 
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("triggerUpdateCmd: Invalid number of arguments %d; args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d; args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -329,10 +274,7 @@ var triggerUpdateCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("triggerUpdateCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
-
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -340,9 +282,7 @@ var triggerUpdateCmd = &cobra.Command{
             return whiskErr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("triggerUpdateCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -352,40 +292,28 @@ var triggerUpdateCmd = &cobra.Command{
         // Convert the trigger's list of default parameters from a string into []KeyValue
         // The 1 or more --param arguments have all been combined into a single []string
         // e.g.   --p arg1,arg2 --p arg3,arg4   ->  [arg1, arg2, arg3, arg4]
-        if IsDebug() {
-            fmt.Printf("triggerUpdateCmd: parsing parameters: %#v\n", flags.common.param)
-        }
+        whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
         parameters, err := parseParameters(flags.common.param)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerUpdateCmd: parseParameters(%#v) failed: %s\n", flags.common.param, err)
-            }
+            whisk.Debug(whisk.DbgError, "parseParameters(%#v) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
 
-        if IsDebug() {
-            fmt.Printf("triggerUpdateCmd: parsing annotations: %#v\n", flags.common.annotation)
-        }
+        whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
         annotations, err := parseAnnotations(flags.common.annotation)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerUpdateCmd: parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
-            }
+            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
             errStr := fmt.Sprintf("Invalid annotations argument value '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
 
-        if IsDebug() {
-            fmt.Printf("triggerCreateCmd: trigger shared: %s\n", flags.common.shared)
-        }
+        whisk.Debug(whisk.DbgInfo, "Trigger shared: %s\n", flags.common.shared)
         shared := strings.ToLower(flags.common.shared)
         if shared != "yes" && shared != "no" && shared != "" {  // "" means argument was not specified
-            if IsDebug() {
-                fmt.Printf("triggerCreateCmd: shared argument value '%s' is invalid\n", flags.common.shared)
-            }
+            whisk.Debug(whisk.DbgError, "Shared argument value '%s' is invalid\n", flags.common.shared)
             errStr := fmt.Sprintf("Invalid --shared argument value '%s'; valid values are 'yes' or 'no'", flags.common.shared)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), nil, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -411,9 +339,7 @@ var triggerUpdateCmd = &cobra.Command{
 
         retTrigger, _, err := client.Triggers.Insert(trigger, true)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerUpdateCmd: client.Triggers.Insert(%+v,true) failed: %s\n", trigger, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Triggers.Insert(%+v,true) failed: %s\n", trigger, err)
             errStr := fmt.Sprintf("Unable to update trigger '%s': %s", trigger.Name, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -434,9 +360,7 @@ var triggerGetCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("triggerGetCmd: Invalid number of arguments %d; args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d; args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -444,10 +368,7 @@ var triggerGetCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("triggerGetCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
-
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -455,9 +376,7 @@ var triggerGetCmd = &cobra.Command{
             return whiskErr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("triggerGetCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -466,9 +385,7 @@ var triggerGetCmd = &cobra.Command{
 
         retTrigger, _, err := client.Triggers.Get(qName.entityName)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerGetCmd: client.Triggers.Get(%s) failed: %s\n", qName.entityName, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Triggers.Get(%s) failed: %s\n", qName.entityName, err)
             errStr := fmt.Sprintf("Unable to get trigger '%s': %s", qName.entityName, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -488,9 +405,7 @@ var triggerDeleteCmd = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
         if len(args) != 1 {
-            if IsDebug() {
-                fmt.Printf("triggerDeleteCmd: Invalid number of arguments %d; args: %#v\n", len(args), args)
-            }
+            whisk.Debug(whisk.DbgError, "Invalid number of arguments %d; args: %#v\n", len(args), args)
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly one argument is expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -498,10 +413,7 @@ var triggerDeleteCmd = &cobra.Command{
 
         qName, err := parseQualifiedName(args[0])
         if err != nil {
-            if IsDebug() {
-                fmt.Println("triggerDeleteCmd: parseQualifiedName(%s)\nerror: %s\n", args[0], err)
-            }
-
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
             errMsg := fmt.Sprintf("Failed to parse qualified name: %s\n", args[0])
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -509,9 +421,7 @@ var triggerDeleteCmd = &cobra.Command{
             return whiskErr
         }
         if len(qName.namespace) == 0 {
-            if IsDebug() {
-                fmt.Printf("triggerDeleteCmd: Namespace is missing from '%s'\n", args[0])
-            }
+            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
             errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -520,9 +430,7 @@ var triggerDeleteCmd = &cobra.Command{
 
         _, err = client.Triggers.Delete(qName.entityName)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerDeleteCmd: client.Triggers.Delete(%s) failed: %s\n", qName.entityName, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Triggers.Delete(%s) failed: %s\n", qName.entityName, err)
             errStr := fmt.Sprintf("Unable to delete trigger '%s': %s", qName.entityName, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -543,27 +451,20 @@ var triggerListCmd = &cobra.Command{
         if len(args) == 1 {
             qName, err = parseQualifiedName(args[0])
             if err != nil {
-                if IsDebug() {
-                    fmt.Printf("triggerListCmd: parseQualifiedName(%#v) error: %s\n", args[0], err)
-                }
+                whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
                 errStr := fmt.Sprintf("'%s' is not a valid qualified name: %s", args[0], err)
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }
             ns := qName.namespace
             if len(ns) == 0 {
-                if IsDebug() {
-                    fmt.Printf("triggerListCmd: Namespace is missing from '%s'\n", args[0])
-                }
+                whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
                 errStr := fmt.Sprintf("No valid namespace detected.  Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }
-
             client.Namespace = ns
-            if IsDebug() {
-                fmt.Printf("triggerListCmd: Using namespace '%s' from argument '%s''\n", ns, args[0])
-            }
+            whisk.Debug(whisk.DbgInfo, "Using namespace '%s' from argument '%s''\n", ns, args[0])
 
             if pkg := qName.packageName; len(pkg) > 0 {
                 // todo :: scope call to package
@@ -576,9 +477,7 @@ var triggerListCmd = &cobra.Command{
         }
         triggers, _, err := client.Triggers.List(options)
         if err != nil {
-            if IsDebug() {
-                fmt.Printf("triggerListCmd: client.Triggers.List(%#v) for namespace '%s' failed: %s\n", options, client.Namespace, err)
-            }
+            whisk.Debug(whisk.DbgError, "client.Triggers.List(%#v) for namespace '%s' failed: %s\n", options, client.Namespace, err)
             errStr := fmt.Sprintf("Unable to obtain the trigger list for namespace '%s': %s", client.Namespace, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -597,15 +496,11 @@ func createFeed (triggerName string, FullFeedName string, parameters []string) e
     flags.common.blocking = true
     err := actionInvokeCmd.RunE(nil, feedArgs)
     if err != nil {
-        if IsDebug() {
-            fmt.Printf("createFeed: Invoke of action '%s' failed: %s\n", FullFeedName, err)
-        }
+        whisk.Debug(whisk.DbgError, "Invoke of action '%s' failed: %s\n", FullFeedName, err)
         errStr := fmt.Sprintf("Unable to invoke trigger '%s' feed action '%s'; feed is not configured: %s", triggerName, FullFeedName, err)
         err = whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
     } else {
-        if IsDebug() {
-            fmt.Printf("createFeed: Successfully configured trigger feed via feed action '%s'\n", FullFeedName)
-        }
+        whisk.Debug(whisk.DbgInfo, "Successfully configured trigger feed via feed action '%s'\n", FullFeedName)
     }
 
     flags.common.param = originalParams
@@ -616,9 +511,7 @@ func deleteTrigger (triggerName string) error {
     args := []string {triggerName}
     err := triggerDeleteCmd.RunE(nil, args)
     if err != nil {
-        if IsDebug() {
-            fmt.Printf("deleteTrigger: trigger '%s' delete failed: %s\n", triggerName, err)
-        }
+        whisk.Debug(whisk.DbgError, "Trigger '%s' delete failed: %s\n", triggerName, err)
         errStr := fmt.Sprintf("Unable to delete trigger '%s': %s", triggerName, err)
         err = whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
     }


### PR DESCRIPTION
- Replace IsDebug()/fmt.Print\* with Whisk.Debug() in all commands*.go modules
- Fix error output in action invoke so that the incorrectActionInvoke test passes
