### PR TITLE
Fixes for skip and limit URL query parameter handling

### DIFF
--- a/tools/go-cli/go-whisk-cli/commands/package.go
+++ b/tools/go-cli/go-whisk-cli/commands/package.go
@@ -586,7 +586,7 @@ func init() {
 
     packageListCmd.Flags().StringVar(&flags.common.shared, "shared", "", "include publicly shared entities in the result")
     packageListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, "skip this many entities from the head of the collection")
-    packageListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 0, "only return this many entities from the collection")
+    packageListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, "only return this many entities from the collection")
     packageListCmd.Flags().BoolVar(&flags.common.full, "full", false, "include full entity description")
 
     packageCmd.AddCommand(

--- a/tools/go-cli/go-whisk-cli/commands/trigger.go
+++ b/tools/go-cli/go-whisk-cli/commands/trigger.go
@@ -533,7 +533,7 @@ func init() {
     triggerFireCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "default parameters")
 
     triggerListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, "skip this many entities from the head of the collection")
-    triggerListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 0, "only return this many entities from the collection")
+    triggerListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, "only return this many entities from the collection")
 
     triggerCmd.AddCommand(
         triggerFireCmd,

--- a/tools/go-cli/go-whisk/whisk/action.go
+++ b/tools/go-cli/go-whisk/whisk/action.go
@@ -110,8 +110,8 @@ type Exec struct {
 }
 
 type ActionListOptions struct {
-    Limit           int  `url:"limit,omitempty"`
-    Skip            int  `url:"skip,omitempty"`
+    Limit           int  `url:"limit"`
+    Skip            int  `url:"skip"`
     Docs            bool `url:"docs,omitempty"`
 }
 

--- a/tools/go-cli/go-whisk/whisk/package.go
+++ b/tools/go-cli/go-whisk/whisk/package.go
@@ -103,8 +103,8 @@ type BindingUpdates struct {
 
 type PackageListOptions struct {
     Public bool `url:"public,omitempty"`
-    Limit  int  `url:"limit,omitempty"`
-    Skip   int  `url:"skip,omitempty"`
+    Limit  int  `url:"limit"`
+    Skip   int  `url:"skip"`
     Since  int  `url:"since,omitempty"`
     Docs   bool `url:"docs,omitempty"`
 }

--- a/tools/go-cli/go-whisk/whisk/rule.go
+++ b/tools/go-cli/go-whisk/whisk/rule.go
@@ -39,8 +39,8 @@ type Rule struct {
 }
 
 type RuleListOptions struct {
-    Limit int  `url:"limit,omitempty"`
-    Skip  int  `url:"skip,omitempty"`
+    Limit int  `url:"limit"`
+    Skip  int  `url:"skip"`
     Docs  bool `url:"docs,omitempty"`
 }
 

--- a/tools/go-cli/go-whisk/whisk/trigger.go
+++ b/tools/go-cli/go-whisk/whisk/trigger.go
@@ -49,8 +49,8 @@ type TriggerFromServer struct {
 }
 
 type TriggerListOptions struct {
-    Limit int  `url:"limit,omitempty"`
-    Skip  int  `url:"skip,omitempty"`
+    Limit int  `url:"limit"`
+    Skip  int  `url:"skip"`
     Docs  bool `url:"docs,omitempty"`
 }
 

--- a/tools/go-cli/go-whisk/whisk/util.go
+++ b/tools/go-cli/go-whisk/whisk/util.go
@@ -34,6 +34,7 @@ func addRouteOptions(route string, options interface{}) (string, error) {
         return route, nil
     }
 
+    Debug(DbgInfo, "Adding options %+v to route '%s'\n", options, route)
     u, err := url.Parse(route)
     if err != nil {
         Debug(DbgError,"url.Parse(%s) error: %s\n", route, err)


### PR DESCRIPTION
- Fixes for skip and limit URL query parameter handling:
  - Allow for 0 value skip and limit
  - Use a default of 30 for limit for all 'list' subcommands
